### PR TITLE
Phil/better down command

### DIFF
--- a/scripts/commands.sh
+++ b/scripts/commands.sh
@@ -23,26 +23,26 @@ up_command() {
 }
 
 ######################################################################
-# down
+# Stop: Stops the running container(s) without removing them
 ######################################################################
 
-run_down() {
+run_stop() {
     check_workspace
     local workspace_dir=$(get_workspace_dir)
     local devcontainer_config=$(get_devcontainer_config ".configuration")
 
-    local command=$(down_command "$devcontainer_config")
+    local command=$(stop_command "$devcontainer_config")
     tmux new-window -n "devcontainer_down" -c "$workspace_dir" "tmux set-option remain-on-exit failed; ${command} && tmux refresh-client -S"
 }
 
-test_down() {
-    debug "Running Down"
+test_stop() {
+    debug "Running Stop"
     local devcontainer_config=$(get_devcontainer_config ".configuration")
-    local command=$(down_command "$devcontainer_config")
+    local command=$(stop_command "$devcontainer_config")
     eval "$command"
 }
 
-down_command() {
+stop_command() {
     local devcontainer_config=$1
     local workspace_dir=$(get_workspace_dir)
 
@@ -68,32 +68,32 @@ down_command() {
 }
 
 ######################################################################
-# purge
+# Down: Stops and removes the container(s), networks, and volumes
 ######################################################################
 
-run_purge() {
+run_down() {
     check_workspace
-    run_down
+    run_stop
 
     local workspace_dir=$(get_workspace_dir)
     local devcontainer_config=$(get_devcontainer_config ".configuration")
-    local command=$(purge_command "$devcontainer_config")
+    local command=$(down_command "$devcontainer_config")
 
     tmux new-window -n "devcontainer_down" -c "$workspace_dir" "tmux set-option remain-on-exit failed; ${purge_command} && tmux refresh-client -S"
 }
 
-test_purge() {
-    debug "Running Purge"
+test_down() {
+    debug "Running Down"
 
-    test_down
+    test_stop
 
     local devcontainer_config=$(get_devcontainer_config ".configuration")
-    local command=$(purge_command "$devcontainer_config")
+    local command=$(down_command "$devcontainer_config")
 
     eval "$command"
 }
 
-purge_command() {
+down_command() {
     local devcontainer_config="$1"
     local workspace_dir=$(get_workspace_dir)
 
@@ -115,14 +115,6 @@ purge_command() {
                 echo "docker rm $container_id"
             fi ;;
     esac
-}
-
-
-
-run_rebuild() {
-    check_workspace
-    run_purge
-    run_up
 }
 
 run_exec_in_popup() {

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -10,19 +10,15 @@ show_menu() {
 
 show_active_menu() {
     local project_name=$(get_devcontainer_config ".configuration.name")
+#         "ReBuild"               r "run -b 'source $CURRENT_DIR/commands.sh && run_rebuild'" \
 
     tmux display-menu -T " Devcontainers " \
         "" \
         "-Workspace: #[fg=white]${project_name}" "" "" \
         "" \
         "Up"                    u "run -b 'source $CURRENT_DIR/commands.sh && run_up'" \
+        "Stop"                  s "run -b 'source $CURRENT_DIR/commands.sh && run_stop'" \
         "Down"                  d "run -b 'source $CURRENT_DIR/commands.sh && run_down'" \
-        "Purge"                 p "run -b 'source $CURRENT_DIR/commands.sh && run_purge'" \
-        "ReBuild"               r "run -b 'source $CURRENT_DIR/commands.sh && run_rebuild'" \
         "Exec in popup"         e "run -b 'source $CURRENT_DIR/commands.sh && run_exec_in_popup'" \
-        "Exec in new window"    E "run -b 'source $CURRENT_DIR/commands.sh && run_exec_in_window'" \
-        "" \
-        "-All commands work with the devcontainers cli," "" "" \
-        "-except commands specified with 'docker compose'" "" "" \
-        "-Exec commands assume bash is available in the container" "" ""
+        "Exec in new window"    E "run -b 'source $CURRENT_DIR/commands.sh && run_exec_in_window'"
 }

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -16,7 +16,8 @@ show_active_menu() {
         "-Workspace: #[fg=white]${project_name}" "" "" \
         "" \
         "Up"                    u "run -b 'source $CURRENT_DIR/commands.sh && run_up'" \
-        "Down (docker compose)" d "run -b 'source $CURRENT_DIR/commands.sh && run_down'" \
+        "Down"                  d "run -b 'source $CURRENT_DIR/commands.sh && run_down'" \
+        "Purge"                 p "run -b 'source $CURRENT_DIR/commands.sh && run_purge'" \
         "ReBuild"               r "run -b 'source $CURRENT_DIR/commands.sh && run_rebuild'" \
         "Exec in popup"         e "run -b 'source $CURRENT_DIR/commands.sh && run_exec_in_popup'" \
         "Exec in new window"    E "run -b 'source $CURRENT_DIR/commands.sh && run_exec_in_window'" \

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -9,6 +9,7 @@ show_menu() {
 }
 
 show_active_menu() {
+    check_workspace
     local project_name=$(get_devcontainer_config ".configuration.name")
 #         "ReBuild"               r "run -b 'source $CURRENT_DIR/commands.sh && run_rebuild'" \
 

--- a/scripts/statusbar/status.sh
+++ b/scripts/statusbar/status.sh
@@ -18,28 +18,6 @@ get_project_name() {
 }
 
 #####################################################################
-#
-# get_docker_compose_files
-#
-# Try to get the the docker compose files from the devcontainer config
-# and return their full path
-#
-#####################################################################
-get_docker_compose_files() {
-    local devcontainer_config="$1"
-    local compose_files=$(echo "$devcontainer_config" | jq -r ".dockerComposeFile | arrays // [.] | .[]")
-    local workspace_dir=$(get_workspace_dir)
-    local compose_files_full_path=""
-
-    for compose_file in ${compose_files}
-    do
-        compose_files_full_path="${compose_files_full_path} ${workspace_dir}/.devcontainer/${compose_file}"
-    done
-
-    echo "${compose_files_full_path}"
-}
-
-#####################################################################
 # status_from_docker_compose
 # return devcontainer status when using docker compose
 # This function handles multiple compose files and merges their status
@@ -52,7 +30,7 @@ status_from_docker_compose() {
 
     # setup docker compose command with all compose files
     local docker_compose_command="docker compose"
-    for compose_file in ${compose_files}
+    for compose_file in ${compose_files[*]}
     do
         docker_compose_command="${docker_compose_command} -f ${compose_file}"
     done
@@ -112,26 +90,6 @@ status_from_image() {
     echo "$image_short_name:${container_status:-unknown}"
 }
 
-#####################################################################
-# detect_orchestration
-# Detect which orchestration method is used in the devcontainer
-#####################################################################
-detect_orchestration() {
-    local devcontainer_config="$1"
-    local orchestrator=""
-
-    if [[ -n $(echo $devcontainer_config | jq -r '.dockerComposeFile // ""') ]]; then
-        orchestrator="compose"
-    elif [[ -n $(echo $devcontainer_config | jq -r '.dockerFile // ""') ]]; then
-        orchestrator="docker"
-    elif [[ -n $(echo $devcontainer_config | jq -r '.image // ""') ]]; then
-        orchestrator="image"
-    else
-        orchestrator="none"
-    fi
-
-    echo "${orchestrator}"
-}
 
 #####################################################################
 # Main code


### PR DESCRIPTION
The menu now has naming that better matches the docker command equivalent:
- Up: builds and runs the devcontainers
- Stop: just stops the containers, and could be started again
- Down: stops and removes the containers. This now works for all orchestration types: image, Dockerfile, and docker compose.

This change also includes support for running the tests via tmux-devcontainers-examples