### PR TITLE
Call functions from bash script directly instead of sourcing them

### DIFF
--- a/devcontainers.tmux
+++ b/devcontainers.tmux
@@ -31,8 +31,8 @@ main() {
     interpolate_tmux_option "status-right"
     interpolate_tmux_option "status-left"
 
-    tmux bind-key $(get_tmux_option "@devcontainers_exec_key" "E") "run -b 'source $CURRENT_DIR/scripts/commands.sh && run_exec_in_window'"
-    tmux bind-key $(get_tmux_option "@devcontainers_menu_key" "C-e") "run -b 'source $CURRENT_DIR/scripts/menu.sh && show_menu'"
+    tmux bind-key $(get_tmux_option "@devcontainers_exec_key" "E") "run -b '$CURRENT_DIR/scripts/commands.sh run_exec_in_window'"
+    tmux bind-key $(get_tmux_option "@devcontainers_menu_key" "C-e") "run -b '$CURRENT_DIR/scripts/menu.sh show_menu'"
 }
 
 main

--- a/scripts/commands.sh
+++ b/scripts/commands.sh
@@ -127,3 +127,4 @@ run_exec_in_window() {
     tmux new-window "devcontainer exec --workspace-folder $(get_workspace_dir) $(get_exec_command)"
 }
 
+"$@"

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -17,9 +17,11 @@ show_active_menu() {
         "" \
         "-Workspace: #[fg=white]${project_name}" "" "" \
         "" \
-        "Up"                    u "run -b 'source $CURRENT_DIR/commands.sh && run_up'" \
-        "Stop"                  s "run -b 'source $CURRENT_DIR/commands.sh && run_stop'" \
-        "Down"                  d "run -b 'source $CURRENT_DIR/commands.sh && run_down'" \
-        "Exec in popup"         e "run -b 'source $CURRENT_DIR/commands.sh && run_exec_in_popup'" \
-        "Exec in new window"    E "run -b 'source $CURRENT_DIR/commands.sh && run_exec_in_window'"
+        "Up"                    u "run -b '$CURRENT_DIR/commands.sh run_up'" \
+        "Stop"                  s "run -b '$CURRENT_DIR/commands.sh run_stop'" \
+        "Down"                  d "run -b '$CURRENT_DIR/commands.sh run_down'" \
+        "Exec in popup"         e "run -b '$CURRENT_DIR/commands.sh run_exec_in_popup'" \
+        "Exec in new window"    E "run -b '$CURRENT_DIR/commands.sh run_exec_in_window'"
 }
+
+"$@"


### PR DESCRIPTION
On Ubuntu 22.04 with tmux 3.5a, I get these errors when I try the keybinds prefix + E and prefix + (Ctrl + e):

```
 'source /home/tgharib/.tmux/plugins/tmux-devcontainers/scripts/commands.sh && run_exec_in_window' returned 127                      [0/0]

'source /home/tgharib/.tmux/plugins/tmux-devcontainers/scripts/menu.sh && show_menu' returned 127                                   [0/0]
```

Changing `source` to `.` worked for `commands.sh` but not `menu.sh` oddly enough. I created this PR as an alternative to the source approach.